### PR TITLE
API url updated

### DIFF
--- a/app.js
+++ b/app.js
@@ -111,7 +111,13 @@ let driver
 
 let year = new Date().getFullYear()
 
-axios.get("https://ergast.com/api/f1/1950/driverStandings.json?limit=1000").then(async () => {
+function sleep(ms) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+axios.get("https://api.jolpi.ca/ergast/f1/1950/driverStandings.json?limit=1000").then(async () => {
     await updateDrivers()
 }).catch(() => {
     console.log("API is unreachable! Not updating drivers...")
@@ -130,7 +136,7 @@ axios.get("https://ergast.com/api/f1/1950/driverStandings.json?limit=1000").then
 })
 
 schedule.scheduleJob("59 23 * * *", async () => {
-    axios.get("https://ergast.com/api/f1/1950/driverStandings.json?limit=1000").then(async () => {
+    axios.get("https://api.jolpi.ca/ergast/f1/1950/driverStandings.json?limit=1000").then(async () => {
         await updateDrivers()
     }).catch(() => {
         console.log("API is unreachable! Not updating drivers...")
@@ -151,7 +157,7 @@ async function updateDrivers() {
     for (let i = 2000; i <= year; i++) {
         console.log(`Scraping F1 ${i} Season...`)
         try {
-            await axios.get(`http://ergast.com/api/f1/${i}/driverStandings.json?limit=1000`).then(res => {
+            await axios.get(`https://api.jolpi.ca/ergast/f1/${i}/driverStandings.json?limit=1000`).then(res => {
                 res.data.MRData.StandingsTable.StandingsLists[0].DriverStandings.forEach(driver => {
                     if (driver.Driver.driverId in newDrivers) {
                         newDrivers[driver.Driver.driverId].wins += parseInt(driver.wins)
@@ -174,6 +180,7 @@ async function updateDrivers() {
         } catch (e) {
             if (i !== year) throw ""
         }
+        await sleep(300)
     }
     drivers = newDrivers
 


### PR DESCRIPTION
To address #8 

Updated the API url to [jolpica-f1](https://github.com/jolpica/jolpica-f1) now that Ergast is offline.

Added a sleep to avoid hitting the new rate limit (max of 4 per second from what I can see)