### PR TITLE
Resolution for undefined error when selecting Franco Colapinto

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,7 +36,7 @@ const flag = {
     "Italian": "it",
     "Monegasque": "mc",
     "Chinese": "cn",
-    "Argentinian": "ar",
+    "Argentine": "ar",
     "Andorran": "ad",
     "Emirati": "ae",
     "Afghan": "af",


### PR DESCRIPTION
This PR fixes the nationality returned in the API file. It was previously "Argentinian", but the correct term used is "Argentine".